### PR TITLE
Chore(.github/workflows/text-lint): 実行条件の追加

### DIFF
--- a/.github/workflows/text-lint.yml
+++ b/.github/workflows/text-lint.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths: 
       - "**/*.md"
-      - ".github/workflows/lint.yml"
+      - ".github/workflows/**"
+      - "package.json"
+      - "package-lock.json"
       - "!**/CLAUDE.md"
 
   workflow_dispatch:


### PR DESCRIPTION
当該リポジトリでtext-lintの実行をRequiredにしたので、Dependabotのauto-mergeに対応できるように実行の条件を追加