### PR TITLE
Chore(.github/workflows/secret-scan): reusable workflowを使用するように

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,12 +10,5 @@ on:
       - main
 
 jobs:
-  secret-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: secret lint
-        run: |
-          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" \
-          secretlint/secretlint secretlint --maskSecrets '**/*'
+  call:
+    uses: ryoooosk/reusable-workflows/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
This pull request updates the secret scanning workflow to use a reusable workflow instead of maintaining the job definition locally. This change simplifies workflow management and makes it easier to update or share the secret scanning process across repositories.

Workflow configuration:

* [`.github/workflows/secret-scan.yml`](diffhunk://#diff-a8f4ad96f6d30e194462559fd052c7a27c77a7a46aca03fce8fc06ff74b2cb05L13-R14): Replaces the local definition of the `secret-scan` job with a call to the reusable workflow at `ryoooosk/reusable-workflows/.github/workflows/secret-scan.yml@main`.