### PR TITLE
chore(.github/workflows/github-actions-lint): reusable workflowを利用するように

### DIFF
--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -3,7 +3,9 @@ name: GitHub Actions lint
 
 on:
   pull_request:
-    paths: [".github/workflows/*yml", ".github/workflows/*yaml"]
+    paths: 
+      - ".github/workflows/*yml"
+      - ".github/workflows/*yaml"
 
 # パイプ処理中のエラーをキャッチするために明示的にシェル指定
 defaults:
@@ -16,10 +18,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  actions-lint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v5
-      - run: |
-          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:latest
+  call:
+    uses: ryoooosk/reusable-workflows/.github/workflows/github-actions-lint.yml@main


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow for linting workflow files. The main change is switching from a locally defined lint job to using a reusable workflow, which simplifies maintenance and improves consistency.

Workflow refactoring:

* Replaced the local `actions-lint` job with a call to a reusable workflow (`ryoooosk/reusable-workflows/.github/workflows/github-actions-lint.yml@main`) for linting GitHub Actions workflow files.

YAML formatting:

* Reformatted the `paths` property to use a multi-line array for better readability and consistency.