### PR TITLE
chore(.github/workflows/dependabot-auto-merge): reusable workflowを利用す…

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,24 +8,10 @@ on:
       - main
 
 jobs:
-  automerge:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+  call:
+    uses: ryoooosk/reusable-workflows/.github/workflows/dependabot-auto-merge.yml@main
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Dependabot metadata
-        id: meta
-        uses: dependabot/fetch-metadata@v2 ## dependabotの更新内容を取得（https://github.com/dependabot/fetch-metadata）
-      - name: Auto approve and merge
-        if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.update-type != 'version-update:semver-major' }}
-        run: |
-          # リポジトリ設定のAllow GitHub Actions to create and approve pull requestsを有効にしておく必要あり
-          gh pr review ${{ github.event.number }} --approve
-          # autoフラグはリポジトリ設定のAllow auto-mergeを有効にしておく必要あり
-          gh pr merge ${{ github.event.number }} --merge --auto
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the Dependabot auto-merge workflow to use a reusable workflow from an external repository, simplifying the configuration and maintenance of the workflow.

Workflow configuration update:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L11-R17): Replaces the local implementation of the Dependabot auto-merge job with a call to `ryoooosk/reusable-workflows/.github/workflows/dependabot-auto-merge.yml@main`, removing all local steps and related environment setup.…るように